### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/api/services/TokenService.js
+++ b/api/services/TokenService.js
@@ -7,7 +7,7 @@
  */
 const jwt = require('jwt-simple')
 const moment = require('moment')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const R = require('ramda')
 
 let Jwt

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "jwt-simple": "^0.5.0",
     "lodash": "^4.13.1",
     "moment": "^2.14.1",
-    "node-uuid": "^1.4.7",
     "passport": "^0.3.2",
     "passport-google-oauth": "^1.0.0",
     "passport-http": "^0.3.0",
@@ -38,6 +37,7 @@
     "require-all": "^2.0.0",
     "sails": "^0.12.3",
     "url": "^0.11.0",
+    "uuid": "^3.0.0",
     "waterline-criteria": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.